### PR TITLE
Update Vercel CLI dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "prettier": "^3.9.4",
         "tailwindcss": "^4.3.2",
         "typescript": "^6.0.3",
-        "vercel": "^54.18.6"
+        "vercel": "^56.3.2"
       },
       "engines": {
         "node": "22.x"
@@ -1930,9 +1930,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1976,9 +1976,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -2008,9 +2008,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
@@ -2040,9 +2040,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
@@ -2056,9 +2056,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
@@ -2072,9 +2072,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -2088,9 +2088,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -3180,13 +3180,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@ts-morph/common": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
@@ -3992,13 +3985,13 @@
       ]
     },
     "node_modules/@vercel/backends": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.21.tgz",
-      "integrity": "sha512-c0mKXgfxMyb44+kMGbNoQJomf37QAfd6yL/2imhAnAChR1Ddkxk6uwbrOC89LcG+QmN2ZoEFUSJdMInSfreztw==",
+      "version": "0.8.25",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.25.tgz",
+      "integrity": "sha512-x+Amcl3weuQ0nUk3UcVpdD++jHoHbI1YZDLSJCXVC9iLrtUy1QzSJRb29cWMHtX+ixAjWXhVqd720xcU7PZfTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/build-utils": "13.32.2",
+        "@vercel/build-utils": "13.34.0",
         "@vercel/nft": "1.10.0",
         "@vercel/static-config": "3.4.0",
         "execa": "3.2.0",
@@ -4052,9 +4045,9 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.32.2",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.32.2.tgz",
-      "integrity": "sha512-XgATgMjt2NHF6HHo1wii6f43qlWjaFx3o+9L7aOUPLQgqwgYp2BGwuuBjg8U6sNgut1QsmFBMvNqTAUBvack9Q==",
+      "version": "13.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.34.0.tgz",
+      "integrity": "sha512-DhbYXymwjO6N3prqBf7UzQFNpQIcHabe1qbiXxqqfjDJ5Tca9+MMYnU/+uObHrPBfR9FAXMxAwmkIUw59zJ7cw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4063,21 +4056,14 @@
         "es-module-lexer": "1.5.0"
       }
     },
-    "node_modules/@vercel/build-utils/node_modules/es-module-lexer": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
-      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vercel/cervel": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.29.tgz",
-      "integrity": "sha512-tjwW6bj1g9qwOO0y/3WTGiarvyWmsWOtLkPB0esFmnscMZCxRqzNh0WJqrbbWxMdC5A2LXzDDHuZ4sXpRg4Tqw==",
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.33.tgz",
+      "integrity": "sha512-osM85mDIVLOUt+ngSBRXpruKuxPgRFi7JR0JbFzdF95VwFsDo2fryUyqPis5yRJA4SkteZK6eADtrj6Vj9W76Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.8.21"
+        "@vercel/backends": "0.8.25"
       },
       "bin": {
         "cervel": "bin/cervel.mjs"
@@ -4138,9 +4124,9 @@
       }
     },
     "node_modules/@vercel/container": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/container/-/container-0.0.4.tgz",
-      "integrity": "sha512-lbUnpg2Iawoi0oDlFE6Se43FNUd2B2nMnCXD9Af7NsysMENFaNu2ajzgsocTxt+O6djUgW9IdBnIRHgnHs+vZQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/container/-/container-0.0.5.tgz",
+      "integrity": "sha512-kYggcjyTsBKbQi3wM647x6g174OrriK9oNQ/KI9LGAwBKqZ75g4zir88cNO3FcLiA6RJ4pQe74wyAisxhDgR5A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -4155,13 +4141,13 @@
       }
     },
     "node_modules/@vercel/elysia": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.98.tgz",
-      "integrity": "sha512-VJMPfvslPFP5lg7oNN+BZEXHdaejmI25OEyco5OvZWpR80MYpTPil+2+hbkoR6lN3kVUC9/xahtgsdfouOvNbA==",
+      "version": "0.1.102",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.102.tgz",
+      "integrity": "sha512-FyYhX6UKcRaBhsR1wsn6nGxKif406ymQkvbYXsMvBBIB1SXbvLVcczINJrG525kjcffWk+28VttJG8jzQsWP6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0"
       }
     },
@@ -4173,15 +4159,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/express": {
-      "version": "0.1.112",
-      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.112.tgz",
-      "integrity": "sha512-Xpw1/+G/NpWYzBh3HqT+npYKo+yrLhSKC+hekBYCoddfDjSTevF1hQSbdEo7oHbZbgQo7h5Rb2vWVQ404zSmkA==",
+      "version": "0.1.116",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.116.tgz",
+      "integrity": "sha512-gedcLxHIE4PIJa3iLMiSt5XDd85/1k/5Fp+jmuoh/MZh9aNqZLLC9LpgJRmFGHffKp6C1YeDL+WUVEiLRBqarA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/cervel": "0.1.29",
+        "@vercel/cervel": "0.1.33",
         "@vercel/nft": "1.10.0",
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -4200,13 +4186,13 @@
       }
     },
     "node_modules/@vercel/fastify": {
-      "version": "0.1.101",
-      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.101.tgz",
-      "integrity": "sha512-+oUCBpSs8ANQmdQB6CTCWTfdxKutCzKEMkMtUJVLVnO0eaiONADkZeaFjjZwMl4Cg6z49ifhJ3QVJD1IWwIwsA==",
+      "version": "0.1.105",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.105.tgz",
+      "integrity": "sha512-GQshcPm/4zQQhq3c+ZOQALoURFxWiYjt8mxQdBB8jADP0pkXGQqAL7Lah7sMq9JDTAjO7fp0m9QTnolTwlUomA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0"
       }
     },
@@ -4302,14 +4288,14 @@
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.2.24",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.24.tgz",
-      "integrity": "sha512-+rqPToquzHOnSsist6FylJY++Z7ScRvl87gJshGhYYXJSCMki5zquX+D8wliOb5H0SW3KGwmTNQ10gUJt52c8w==",
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.28.tgz",
+      "integrity": "sha512-bchletKw9NBeTkShh8qrr+MmHomPSw4VtYVYB+T2KsDXuMOdTTDAB2txYXRAyVqnOLAwG+GWjVdyXB9mGdWOHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "13.32.2",
+        "@vercel/build-utils": "13.34.0",
         "esbuild": "0.27.0",
         "etag": "1.8.1",
         "fs-extra": "11.1.0"
@@ -4323,25 +4309,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/h3": {
-      "version": "0.1.107",
-      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.107.tgz",
-      "integrity": "sha512-Vqo5AvE5ku3MIWAi56KlYbLIg/PfX7Xxp94xbNa7J7dbREbO8PZWD0QLKvOw1uGqyoa5YqNZZ3RdtCfDq9Z6oA==",
+      "version": "0.1.111",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.111.tgz",
+      "integrity": "sha512-k/klevIqGcn+p1j0uNWf1UskbZATwubNXpSwaZXb+HW3zGx6sgoSlR4L0+fIUSWlWwBroHhNauKeG0ZoTFHobg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/hono": {
-      "version": "0.2.101",
-      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.101.tgz",
-      "integrity": "sha512-sm24D5OUJEo9cuvPHeVgouuc0zhZdIhX28BdtvIek5b7FGmvOE8VExOhteWU5YufhJR0M1y1zbbVC2ULr/arHw==",
+      "version": "0.2.105",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.105.tgz",
+      "integrity": "sha512-F8QHB2gAL/zXaNj2peVkrwpkqlUgkV0DCb4fOYt1CuCesHFLSPfhkl/gO6wjGOmqDIpBAE9lOaWm8AzLWunZ1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.10.0",
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
@@ -4371,31 +4357,31 @@
       }
     },
     "node_modules/@vercel/koa": {
-      "version": "0.1.81",
-      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.81.tgz",
-      "integrity": "sha512-sAavmnlTM9LhYPWAgIvWuKgpeozk/tB4ZPLe/Fl7qE6EJiN3sCjtaSatXhla5w1Zxy0veBI5u0LCcjref4Oxag==",
+      "version": "0.1.85",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.85.tgz",
+      "integrity": "sha512-9388s1YZuPlrmcTyZiJ1EKikab1o4h8C/TKi7uqvSMPDT4q829QdiAmVpjdKl06FcuypzibMsZlB5XZbosxtfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/nestjs": {
-      "version": "0.2.102",
-      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.102.tgz",
-      "integrity": "sha512-CMDoq4dFBI1rLmAuya7UPXfcg7h0y1xdNVCeFhzlZOfp7EF1+PFkn3dVF8tIX46yiUFCz94weiLHSAoh+mRD4g==",
+      "version": "0.2.106",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.106.tgz",
+      "integrity": "sha512-dg1ld/FCYUnfiMUwf5P+Z87V2chVLgwETeQTSDocI3gIztIlqHBoPw5CCboprsjHs39TRSFhugYQMJJlq9C3hg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
+        "@vercel/node": "5.8.26",
         "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/next": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.20.2.tgz",
-      "integrity": "sha512-mroXgsjkmI6i5m1dMRmFNHO8wExhhgOzFRHT0pg195uOVyuNU2JxBCtU47FowbcnLbrAmIfStWkPSHLwPRh6FA==",
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.20.4.tgz",
+      "integrity": "sha512-8m39IHTAgO5yE9xAW8lnjv01z8qQ/qm1FWqyg46qBH2GPtn0MHEME2tAbRy+XzV0Q2J/KGSwmH4xFq8FgECAfg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4443,9 +4429,9 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.8.22",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.22.tgz",
-      "integrity": "sha512-WfciIhDVh9RwFmvrWp7FAdYCBPV94bZvIo4JbaHqZbvBJ2Bmnv/Pgj1fTjjLKfnKTbLJy+8HN1FXB8KYDnwGZQ==",
+      "version": "5.8.26",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.26.tgz",
+      "integrity": "sha512-Vh7V6aWgUtzMLqd+n7K4O4KzXjB9UxV71OGCp5NODPqHvjpbavwjUfPlnKAXyZTZxQrbp+HHv+mL/6J8ezB8Hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4453,7 +4439,7 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.32.2",
+        "@vercel/build-utils": "13.34.0",
         "@vercel/error-utils": "2.2.0",
         "@vercel/nft": "1.10.0",
         "@vercel/static-config": "3.4.0",
@@ -4492,6 +4478,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/@vercel/node/node_modules/es-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/node/node_modules/node-fetch": {
       "version": "2.6.9",
@@ -4560,9 +4553,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python": {
-      "version": "6.47.3",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.47.3.tgz",
-      "integrity": "sha512-h8j5Fln+GYPkWCIXZdhUq1ibFQofjeiV6LMgeY31NEFn/lolz/UxDwqSZswM9H1aP/5lH54VCe/iFE4dMlSWiQ==",
+      "version": "6.51.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.51.0.tgz",
+      "integrity": "sha512-81n05giwRNXwp7UZQbDoSHv8XhQTsFRfQnlFSaITmsWA8MVl1t1XJrrHSNswiRm+hceWzHxBZxE0ysfWXs4AQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4692,13 +4685,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/rust": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.3.0.tgz",
-      "integrity": "sha512-z1X0z1NM+ISunm/scgRpuENNwcKlh7DjXn0QvKE0n10DcaYqxkBQVK8iRA9X05xSK9AzPlnB9DHdGKiXZO5buw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.4.0.tgz",
+      "integrity": "sha512-/zRJtaf3pvdxZ7+tShmIo8StdbkCSBDcY7Gy7LOwNTIxm6GU9vkS+BlCwJHkOu6qNkbcSRH6ZQIeo4vNmqzKdQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "execa": "5",
+        "get-port": "5.1.1",
         "smol-toml": "1.5.2"
       }
     },
@@ -4757,9 +4751,9 @@
       "license": "ISC"
     },
     "node_modules/@vercel/sandbox": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.1.1.tgz",
-      "integrity": "sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.4.0.tgz",
+      "integrity": "sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4773,7 +4767,7 @@
         "tar-stream": "3.1.7",
         "undici": "^7.27.1",
         "xdg-app-paths": "5.1.0",
-        "zod": "3.24.4"
+        "zod": "^4.1.1"
       }
     },
     "node_modules/@vercel/sandbox/node_modules/jose": {
@@ -4803,25 +4797,15 @@
         "node": ">=20.18.1"
       }
     },
-    "node_modules/@vercel/sandbox/node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@vercel/static-build": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.11.4.tgz",
-      "integrity": "sha512-Cyjsg4yfiSSwRSq4TaYnxDzh3Cembx6hlUCKD0z3QCvEYFjTR3j1bFKk8haekwSB16qg25k9fiPEZMP7B/Azag==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.11.8.tgz",
+      "integrity": "sha512-5XpF+D61dwJIXA7eBLNLtVWyiZYqGFBwLsWnK694yp6Yg0eu/q5trqHLxSvIcpR/DbWDbfJiyVQy/r2UIIAblg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-        "@vercel/gatsby-plugin-vercel-builder": "2.2.24",
+        "@vercel/gatsby-plugin-vercel-builder": "2.2.28",
         "@vercel/static-config": "3.4.0",
         "ts-morph": "12.0.0"
       }
@@ -5122,19 +5106,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -5261,16 +5232,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/basic-ftp": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5282,9 +5243,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5587,16 +5548,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5727,21 +5678,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/depd": {
@@ -5999,9 +5935,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6128,39 +6064,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -6605,20 +6508,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -7085,21 +6974,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -7331,20 +7205,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7458,16 +7318,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8083,6 +7933,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -8703,23 +8560,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8733,14 +8580,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -9217,40 +9064,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9368,9 +9181,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9511,43 +9324,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -9920,15 +9696,16 @@
       "license": "MIT"
     },
     "node_modules/sandbox": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.1.2.tgz",
-      "integrity": "sha512-g93rma0Z9Aa6EoTktzYnGZmQvMzm7j73BekJIMwmkdWR5uryZ+6hBCADtd3JKGAB27k+ubnG7HHsZqtscAMzIQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.4.0.tgz",
+      "integrity": "sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/sandbox": "2.1.1",
+        "@vercel/sandbox": "2.4.0",
         "async-retry": "1.3.3",
         "debug": "^4.4.1",
+        "ws": "^8.21.0",
         "zod": "^4.1.1"
       },
       "bin": {
@@ -10168,17 +9945,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
@@ -10190,36 +9956,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/source-map-js": {
@@ -11079,44 +10815,44 @@
       }
     },
     "node_modules/vercel": {
-      "version": "54.18.6",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-54.18.6.tgz",
-      "integrity": "sha512-0rpxXpEtYvpyqzV80VHDSWw2r+KopWCUkPF43JY2TWKGCbi3Kh0Cdnt2vZFXAqLFHSGS83hnS0S/RHptQcyELQ==",
+      "version": "56.3.2",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-56.3.2.tgz",
+      "integrity": "sha512-UyOL/TMXPOvVyx4SEzpP4kLdv56dUPU4VBRrGzyY+GEBX0o8vTtp+CPOAr1gKAHDgeWdnrD8SGG3D3ONNU+FEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.8.21",
+        "@vercel/backends": "0.8.25",
         "@vercel/blob": "2.4.0",
-        "@vercel/build-utils": "13.32.2",
+        "@vercel/build-utils": "13.34.0",
         "@vercel/cli-auth": "0.3.0",
         "@vercel/cli-config": "0.2.0",
-        "@vercel/container": "0.0.4",
+        "@vercel/container": "0.0.5",
         "@vercel/detect-agent": "1.2.3",
-        "@vercel/elysia": "0.1.98",
-        "@vercel/express": "0.1.112",
-        "@vercel/fastify": "0.1.101",
+        "@vercel/elysia": "0.1.102",
+        "@vercel/express": "0.1.116",
+        "@vercel/fastify": "0.1.105",
         "@vercel/fun": "1.3.0",
         "@vercel/go": "3.10.2",
-        "@vercel/h3": "0.1.107",
-        "@vercel/hono": "0.2.101",
+        "@vercel/h3": "0.1.111",
+        "@vercel/hono": "0.2.105",
         "@vercel/hydrogen": "1.4.0",
-        "@vercel/koa": "0.1.81",
-        "@vercel/nestjs": "0.2.102",
-        "@vercel/next": "4.20.2",
-        "@vercel/node": "5.8.22",
+        "@vercel/koa": "0.1.85",
+        "@vercel/nestjs": "0.2.106",
+        "@vercel/next": "4.20.4",
+        "@vercel/node": "5.8.26",
         "@vercel/prepare-flags-definitions": "0.3.0",
-        "@vercel/python": "6.47.3",
+        "@vercel/python": "6.51.0",
         "@vercel/redwood": "2.5.0",
         "@vercel/remix-builder": "5.9.1",
         "@vercel/ruby": "2.5.1",
-        "@vercel/rust": "1.3.0",
-        "@vercel/static-build": "2.11.4",
+        "@vercel/rust": "1.4.0",
+        "@vercel/static-build": "2.11.8",
         "chokidar": "4.0.0",
         "esbuild": "0.27.0",
         "jose": "5.9.6",
+        "jsonc-parser": "3.3.1",
         "luxon": "^3.4.0",
-        "proxy-agent": "6.4.0",
-        "sandbox": "3.1.2",
+        "sandbox": "3.4.0",
         "smol-toml": "1.5.2",
         "undici": "5.29.0",
         "zod": "4.1.11"
@@ -11298,6 +11034,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xdg-app-paths": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "prettier": "^3.9.4",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
-    "vercel": "^54.18.6"
+    "vercel": "^56.3.2"
   }
 }


### PR DESCRIPTION
## What changed

- Updated the development dependency `vercel` from 54.18.6 to 56.3.2.
- Refreshed the lockfile and accepted safe, non-breaking transitive dependency updates.
- Resolved the lockfile to Next.js 16.2.10 within the existing `^16.2.9` range.

## Why

Most remaining Dependabot alerts are development-only transitive dependencies pulled in by the Vercel CLI. This update moves the project to the current Vercel CLI release and removes outdated packages where upstream has already shipped replacements.

## Security impact

- Full local audit: 34 vulnerabilities → 32 vulnerabilities.
- Production-only audit: unchanged at 2 moderate advisories inherited from Next.js's bundled PostCSS.
- No `npm audit fix --force` was used because it proposes unsafe downgrades.

## Validation

- `npm ci`
- `npm run build` using Next.js 16.2.10
- `npm run lint` (0 errors; 30 existing warnings)
- `npx vercel --version` → 56.3.2
- `npm audit --omit=dev`