### PR TITLE
Center search content and always show instruments

### DIFF
--- a/src/components/common/InstrumentDisplay.tsx
+++ b/src/components/common/InstrumentDisplay.tsx
@@ -1,7 +1,5 @@
 'use client'
-import React, { useState, lazy, Suspense, useMemo } from 'react'
-import { IconContext } from 'react-icons'
-import { RxDoubleArrowUp } from 'react-icons/rx'
+import React, { lazy, Suspense, useMemo } from 'react'
 import type { InstrumentDisplayProps } from '../../types'
 
 // 動的インポートでコード分割
@@ -18,11 +16,6 @@ const LoadingSpinner: React.FC<{ children: string }> = ({ children }) => (
 
 const InstrumentDisplay: React.FC<InstrumentDisplayProps> = (props) => {
   const { musicData, setMusicData, className = '' } = props
-  const [isDisplay, setIsDisplay] = useState(false)
-
-  const handleClick = () => {
-    setIsDisplay(!isDisplay)
-  }
 
   // プロップスをメモ化
   const pianoProps = useMemo(
@@ -58,45 +51,24 @@ const InstrumentDisplay: React.FC<InstrumentDisplayProps> = (props) => {
       className={`instrument-display w-full ${className}`}
       data-testid="instrument-display"
     >
-      {/* トグルボタン */}
-      <div
-        className="flex justify-center items-center cursor-pointer p-4 bg-gray-100 hover:bg-gray-200 transition-colors rounded-lg mb-4"
-        onClick={handleClick}
-      >
-        <IconContext.Provider value={{ size: '1.5em', color: '#333' }}>
-          <div
-            className={`transform transition-transform duration-300 ${
-              isDisplay ? 'rotate-180' : ''
-            }`}
-          >
-            <RxDoubleArrowUp />
-          </div>
-        </IconContext.Provider>
-        <span className="ml-2 text-lg font-medium">
-          {isDisplay ? '楽器を隠す' : '楽器を表示'}
-        </span>
-      </div>
-
       {/* 楽器表示エリア */}
-      {isDisplay && (
-        <div className="space-y-6">
-          {/* ピアノロール */}
-          <div className="bg-white rounded-lg shadow-md p-4">
-            <h3 className="text-lg font-semibold mb-4 text-center">ピアノ</h3>
-            <Suspense fallback={<LoadingSpinner>ピアノ</LoadingSpinner>}>
-              <PianoRoll {...pianoProps} />
-            </Suspense>
-          </div>
-
-          {/* ギターフィンガーボード */}
-          <div className="bg-white rounded-lg shadow-md p-4">
-            <h3 className="text-lg font-semibold mb-4 text-center">ギター</h3>
-            <Suspense fallback={<LoadingSpinner>ギター</LoadingSpinner>}>
-              <Fingerboard {...fingerboardProps} />
-            </Suspense>
-          </div>
+      <div className="space-y-6">
+        {/* ピアノロール */}
+        <div className="bg-white rounded-lg shadow-md p-4">
+          <h3 className="text-lg font-semibold mb-4 text-center">ピアノ</h3>
+          <Suspense fallback={<LoadingSpinner>ピアノ</LoadingSpinner>}>
+            <PianoRoll {...pianoProps} />
+          </Suspense>
         </div>
-      )}
+
+        {/* ギターフィンガーボード */}
+        <div className="bg-white rounded-lg shadow-md p-4">
+          <h3 className="text-lg font-semibold mb-4 text-center">ギター</h3>
+          <Suspense fallback={<LoadingSpinner>ギター</LoadingSpinner>}>
+            <Fingerboard {...fingerboardProps} />
+          </Suspense>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -6,7 +6,7 @@ interface ContainerProps {
 
 const Container: React.FC<ContainerProps> = React.memo(({ children }) => {
   return (
-    <div className="w-full max-w-6xl mx-auto px-10 rounded-lg md:px-0 min-[1500px]:ml-64 min-[1500px]:mx-0">
+    <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 rounded-lg">
       {children}
     </div>
   )

--- a/src/components/pianoAppearance.tsx
+++ b/src/components/pianoAppearance.tsx
@@ -1,5 +1,5 @@
 // CSS modules removed - using unified Tailwind design system
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useEffect, useCallback, useMemo } from 'react'
 import WhiteKey from './whiteKey'
 import BlackKey from './blackKey'
 import React from 'react'
@@ -47,7 +47,10 @@ const PianoAppearance: React.FC<PianoAppearanceProps> = React.memo((props) => {
           ? 'true'
           : 'false'
       )
-      setPrimaryKey(newPrimaryKey)
+
+      if (newPrimaryKey.some((value, index) => value !== primaryKey[index])) {
+        setPrimaryKey(newPrimaryKey)
+      }
     }
   }, [currentKey, setPrimaryKey, primaryKey, keyList])
 


### PR DESCRIPTION
## 概要

コード／スケール検索画面のコンテンツを中央寄せし、ピアノとギターを初期状態から常時表示します。

## 変更内容

- 大画面でコンテンツを左側へ固定していたクラスを削除し、レスポンシブな横余白と中央配置に変更
- 「楽器を表示／隠す」トグルを廃止し、ピアノとギターを常時描画
- 楽器の常時描画で顕在化したピアノの無限更新を防止
- 同ファイルの未使用 React hook import を整理

## 原因

外側コンテナに大画面用の左固定指定があり、楽器コンポーネントは折りたたみ状態から開始していました。また、ピアノの主音同期処理が同じ内容の配列でも state を更新していたため、常時描画時に更新ループが発生していました。

## 影響

検索結果と楽器表示が画面中央に配置され、ユーザー操作なしでピアノとギターを確認できます。

## 検証

- ESLint
- TypeScript `tsc --noEmit`
- `npm run build`
- Playwright CLI によるデスクトップ（1368×700）／モバイル（375×667）表示確認
- ブラウザコンソールエラーなし